### PR TITLE
Escape Dir.pwd using shellwords lib

### DIFF
--- a/lib/provise/commands.rb
+++ b/lib/provise/commands.rb
@@ -1,4 +1,3 @@
 $:.push File.expand_path('../', __FILE__)
 
 require 'commands/ipa'
-

--- a/lib/provise/commands/ipa.rb
+++ b/lib/provise/commands/ipa.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 command :ipa do |c|
 
 	c.syntax = '$ resign ipa [options]'
@@ -81,7 +83,7 @@ command :ipa do |c|
 		say "Packing resigned ipa file to #{new_ipa_file}" unless options.quiet
 
 		# to zip correctly, it must go to the correct path
-		script_folder = Dir.pwd.gsub(" ", "\\ ")
+		script_folder = Shellwords.escape(Dir.pwd)
 		Dir.chdir(@tmp_dir) do
 			system "zip -qr #{script_folder}/#{new_ipa_file} ./Payload/"
 		end


### PR DESCRIPTION
Thanks for this gem! It took me dozens of trials to finally find your script and it works flawlessly.

However, I had an issue re-signing with this gem because my folder structure contained the "(" and ")" characters. I opted to use the Shellwords lib to do the escaping instead of gsub, which should make this library more robust for people that have oddly named folders. Let me know if this is okay, also I would be happy to contribute to the two issues you have listed.
